### PR TITLE
[AT-3287] Create Brokerage subaccount methods

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,23 @@
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- Add here link to Jira, but let this not be the only content in this section -->
+**[JIRA ticket](https://banktothefuture.atlassian.net/browse/XX-1234)**
+
+## Description
+<!--- Describe what you have done and why have you done it this way -->
+
+## Screenshots (if appropriate):
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have added tests to cover my changes.
+- [ ] I have added feature flags to hide new changes on production
+- [ ] I have tested if data is not visible by other user (through modified API call, or URL change)
+- [ ] I have tested what happens if I resubmit form or API call few times
+- [ ] I have tested inputs against tricky strings like `<script>alert('XSS')</script>` or emojis 🐛😺

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 # Project files
 .idea
 config/config.yml
+
+.rakeTasks

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Metrics/LineLength:
+  Max: 100

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,34 @@
 PATH
   remote: .
   specs:
-    binance_api (1.0.1)
+    binance_api (1.1.0)
       rest-client (~> 2.0)
       websocket-client-simple (~> 0.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    coderay (1.1.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     event_emitter (0.2.6)
+    hashdiff (1.0.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    method_source (1.0.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     netrc (0.11.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (4.0.5)
     rake (10.5.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
@@ -36,9 +47,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    safe_yaml (1.0.5)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    vcr (6.0.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.5)
     websocket-client-simple (0.3.0)
       event_emitter
@@ -50,10 +67,13 @@ PLATFORMS
 DEPENDENCIES
   binance_api!
   bundler (~> 1.16)
+  pry
   rake (~> 10.0)
   rest-client (~> 2.0.0)
   rspec (~> 3.0)
+  vcr
+  webmock
   websocket-client-simple (~> 0.3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.17.3

--- a/binance_api.gemspec
+++ b/binance_api.gemspec
@@ -33,6 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'pry'
   spec.add_dependency 'rest-client', "~> 2.0"
   spec.add_dependency 'websocket-client-simple', '~> 0.3.0'
 end

--- a/lib/binance_api.rb
+++ b/lib/binance_api.rb
@@ -1,7 +1,9 @@
 require 'binance_api/version'
+require 'binance_api/request_error'
 require 'binance_api/rest'
 require 'binance_api/wapi'
 require 'binance_api/stream'
+require 'binance_api/brokerage'
 require 'yaml'
 
 module BinanceAPI
@@ -15,6 +17,10 @@ module BinanceAPI
       @wapi ||= BinanceAPI::WAPI.new
     end
 
+    def brokerage
+      @brokerage ||= BinanceAPI::Brokerage.new
+    end
+
     attr_writer :recv_window
 
     def recv_window
@@ -22,6 +28,5 @@ module BinanceAPI
     end
 
     attr_accessor :api_key, :api_secret
-
   end
 end

--- a/lib/binance_api/brokerage.rb
+++ b/lib/binance_api/brokerage.rb
@@ -1,0 +1,67 @@
+require 'rest-client'
+require 'binance_api/base'
+require 'binance_api/result'
+
+module BinanceAPI
+  class Brokerage < BinanceAPI::Base
+    def create_subaccount(options = {})
+      params = base_params(options)
+
+      process_request(:post, "#{BASE_URL}/sapi/v1/broker/subAccount", params)
+    end
+
+    def get_subaccount(subaccount_id = nil, options = {})
+      params = base_params(options).merge(
+        subAccountId: subaccount_id
+      )
+
+      process_request(:get, "#{BASE_URL}/sapi/v1/broker/subAccount", params)
+    end
+
+    protected
+
+    def process_request(method, url, params)
+      response = make_request(method, url, params)
+      validate_response(response)
+      build_result response
+    end
+
+    def make_request(method, url, params)
+      signed_params = params_with_signature(params, api_secret)
+      headers = { 'X-MBX-APIKEY' => api_key }
+      safe do
+        if method == :get
+          RestClient.get url, headers.merge(params: signed_params)
+        else
+          RestClient::Request.execute(
+            method: method,
+            url: url,
+            payload: signed_params,
+            headers: headers
+          )
+        end
+      end
+    end
+
+    def validate_response(response)
+      return if response.code == 200
+
+      raise BinanceAPI::RequestError.new(response.code, response.body)
+    end
+
+    def build_result(response)
+      json = JSON.parse(response.body, symbolize_names: true)
+      BinanceAPI::Result.new(json, response.code == 200)
+    end
+
+    def base_params(options)
+      recv_window = options.delete(:recv_window) || BinanceAPI.recv_window
+      timestamp = options.delete(:timestamp) || Time.now
+
+      {
+        recvWindow: recv_window,
+        timestamp: timestamp.to_i * 1000
+      }
+    end
+  end
+end

--- a/lib/binance_api/request_error.rb
+++ b/lib/binance_api/request_error.rb
@@ -1,0 +1,10 @@
+module BinanceAPI
+  class RequestError < StandardError
+    attr_reader :status, :message
+
+    def initialize(status, message)
+      @status = status
+      @message = message
+    end
+  end
+end

--- a/lib/binance_api/version.rb
+++ b/lib/binance_api/version.rb
@@ -1,3 +1,3 @@
 module BinanceAPI
-  VERSION = "1.0.1"
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/binance_api/brokerage_spec.rb
+++ b/spec/binance_api/brokerage_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe BinanceAPI::Brokerage, :vcr do
+  subject(:brokerage) { BinanceAPI::Brokerage.new }
+
+  describe '.create_subaccount' do
+    context 'when success response' do
+      it 'returns result with created subaccount id' do
+        result = brokerage.create_subaccount
+
+        expect(result.value[:subaccountId]).to be_a(String)
+      end
+    end
+
+    context 'when error response' do
+      before { brokerage.api_secret = 'INVALID_SECRET' }
+
+      it 'throws BinanceAPI::RequestError' do
+        expect { brokerage.create_subaccount }.to raise_error(BinanceAPI::RequestError)
+      end
+
+      it 'throws exception with error message and code' do
+        brokerage.create_subaccount
+      rescue => e
+        expect(e.message).to include('Signature for this request is not valid')
+        expect(e.status).to eq(400)
+      end
+    end
+  end
+
+  describe '.get_subaccount' do
+    context 'when valid subaccount ID' do
+      let(:subaccount_id) { '494553304457687040' }
+
+      it 'returns result with expected keys' do
+        result = brokerage.get_subaccount(subaccount_id)
+
+        expect(result.value.first.keys).to include(:subaccountId, :createTime, :makerCommission)
+      end
+    end
+
+    context 'when invalid subaccount ID' do
+      let(:subaccount_id) { '-1' }
+
+      it 'throws BinanceAPI::RequestError' do
+        expect { brokerage.get_subaccount(subaccount_id) }.to raise_error(BinanceAPI::RequestError)
+      end
+
+      it 'throws exception with error message and code' do
+        brokerage.get_subaccount(subaccount_id)
+      rescue => e
+        expect(e.message).to include('This two users are not in parent-child relation')
+        expect(e.status).to eq(400)
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccount/WhenErrorResponse/throws_BinanceAPI_RequestError.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccount/WhenErrorResponse/throws_BinanceAPI_RequestError.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccount
+    body:
+      encoding: UTF-8
+      string: recvWindow=5000&timestamp=1595920557000&signature=a24ef556bda308da144439e8e90c340bba43830362ed6b53963dee6aab98db84
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.0.0 x86_64) ruby/2.6.3p62
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '63'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 28 Jul 2020 07:15:57 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=F8EDC83E80914C8BADEC6F526F666B10; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 c60880d44880ad913f911851a63aacdf.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - X2lOvgq-io3tkopi-ykDbfkMQWC8nknR6uzjKhTQUGu_bWd30xis7w==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1022,"msg":"Signature for this request is not valid."}'
+  recorded_at: Tue, 28 Jul 2020 07:15:57 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccount/WhenErrorResponse/throws_exception_with_error_message_and_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccount/WhenErrorResponse/throws_exception_with_error_message_and_code.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccount
+    body:
+      encoding: UTF-8
+      string: recvWindow=5000&timestamp=1595920557000&signature=a24ef556bda308da144439e8e90c340bba43830362ed6b53963dee6aab98db84
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.0.0 x86_64) ruby/2.6.3p62
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '63'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 28 Jul 2020 07:15:58 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=45D2BCA8039061AC36DBE51E1228AC4C; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 b3b1689b5de3293227c415784ed3c268.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - k_KcFrdM8qdHUi0Cwq7akTJscqQ8O0hgk26z2HDc2XM5uTAHyFe29g==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1022,"msg":"Signature for this request is not valid."}'
+  recorded_at: Tue, 28 Jul 2020 07:15:58 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccount/WhenSuccessResponse/returns_result_with_created_subaccount_id.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccount/WhenSuccessResponse/returns_result_with_created_subaccount_id.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccount
+    body:
+      encoding: UTF-8
+      string: recvWindow=5000&timestamp=1595920555000&signature=53f6db3a350483fdecd6d7a35d11ffabebd26c879d4d43c567a46f8b53dd1f68
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.0.0 x86_64) ruby/2.6.3p62
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '37'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 28 Jul 2020 07:15:57 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=BBDA2859DE4254497EC8217E45D5F59B; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, OPTIONS
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5d40d4ac7c3a1e18748166636540091f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - reMebY5l70BGVrOeqL7Cs7MVMjP_QCjVsZBwLfUGWwWDwHc9mtozfg==
+    body:
+      encoding: UTF-8
+      string: '{"subaccountId":"494769146829144065"}'
+  recorded_at: Tue, 28 Jul 2020 07:15:57 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/GetSubaccount/WhenInvalidSubaccountID/throws_BinanceAPI_RequestError.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/GetSubaccount/WhenInvalidSubaccountID/throws_BinanceAPI_RequestError.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.binance.com/sapi/v1/broker/subAccount?recvWindow=5000&signature=dfa469735dfae4859f2519e04905c75444d190dbd6d05ed4fa8fba846dc47030&subAccountId=-1&timestamp=1595920559000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.0.0 x86_64) ruby/2.6.3p62
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 28 Jul 2020 07:15:59 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=3D0276F5F440D1C30F71FF78CF1062AE; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 8a90372b0bc378a280335b1e5010d8c4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - vMbuPP-G8bcztJT8Xvo7mdl2H0EuSQj6lh7BF0eMHZz18HSRZm3bjw==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Tue, 28 Jul 2020 07:15:59 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/GetSubaccount/WhenInvalidSubaccountID/throws_exception_with_error_message_and_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/GetSubaccount/WhenInvalidSubaccountID/throws_exception_with_error_message_and_code.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.binance.com/sapi/v1/broker/subAccount?recvWindow=5000&signature=dfa469735dfae4859f2519e04905c75444d190dbd6d05ed4fa8fba846dc47030&subAccountId=-1&timestamp=1595920559000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.0.0 x86_64) ruby/2.6.3p62
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 28 Jul 2020 07:15:59 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=FD2FE31D7BE4FCF17B2BF842E32CF92C; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 4c7664383840971890a08804c2d41e86.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - lG2IO3X5b5B8NNUNh0pbScFVigqPI7dAPEpzQizIzAyJFkp3nGfADA==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Tue, 28 Jul 2020 07:16:00 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/GetSubaccount/WhenValidSubaccountID/returns_result_with_expected_keys.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/GetSubaccount/WhenValidSubaccountID/returns_result_with_expected_keys.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.binance.com/sapi/v1/broker/subAccount?recvWindow=5000&signature=4dd04c7db371afca7c06e7109998e56096edf76047a55b21e19cf21d8e09fd8f&subAccountId=494553304457687040&timestamp=1595920558000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.0.0 x86_64) ruby/2.6.3p62
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '178'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 28 Jul 2020 07:15:58 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=D6DFF814EA5E7F93A833FD2C01A83D6D; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, OPTIONS
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 6f2e6b73507f298a6ce32e365342e612.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - B4GXaZiK2ta9kKQc5gChwbLHdd0h6oHaIT8zjvyBnjJAAV7VnalFtw==
+    body:
+      encoding: UTF-8
+      string: '[{"subaccountId":"494553304457687040","makerCommission":"0.0010","takerCommission":"0.0010","marginMakerCommission":"-1","marginTakerCommission":"-1","createTime":1595869096000}]'
+  recorded_at: Tue, 28 Jul 2020 07:15:59 GMT
+recorded_with: VCR 6.0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require "bundler/setup"
-require "binance_api"
+require 'bundler/setup'
+require 'binance_api'
+require 'vcr'
+require 'pry'
 
 # change to your profile at config/config.yml
 config = YAML.load_file(File.join(__dir__, '..', 'config', 'config.yml'))
@@ -16,6 +18,33 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+end
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  config.hook_into :webmock
+  config.allow_http_connections_when_no_cassette = true
+end
+
+RSpec.configure do |config|
+  config.before(:each, :vcr) do |test|
+    select_or_create_vcr_cassette(test_name: test.description, full_test_context: self.class.name)
+  end
+
+  config.after(:each, :vcr) do
+    VCR.eject_cassette
+  end
+end
+
+def select_or_create_vcr_cassette(test_name: ,full_test_context:)
+  full_path = full_test_context.gsub('::', '/') + "/#{test_name}"
+  full_path.slice!('RSpec/ExampleGroups/')
+  VCR.insert_cassette(
+    full_path,
+    match_requests_on: [
+      :method,
+      VCR.request_matchers.uri_without_params('signature', 'timestamp')]
+  )
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Add here link to Jira, but let this not be the only content in this section -->
**[JIRA ticket](https://banktothefuture.atlassian.net/browse/AT-3287)**

We need to be able to create brokerage subaccount

## Description
<!--- Describe what you have done and why have you done it this way -->

* Create `Brokerage` module with `create_subaccount` and `get_subaccount` methods
* Add `BinanceAPI::RequestError` and throw it when request is invalid in `Brokerage` module. I didn't use this error in other modules now, because it would require much work and I don't want to block the rest of the team now
* Add test
* Cofigure VCR - skip `'signature', 'timestamp'` params when matching requests, this params are changing over time  

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3330162/88633452-51e76a80-d0b5-11ea-9c6e-42209ea8d7d1.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've added test to cover myc changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
- [ ] I have added feature flags to hide new changes on production
- [ ] I have tested if data is not visible by other user (through modified API call, or URL change)
- [ ] I have tested what happens if I resubmit form or API call few times
- [ ] I have tested inputs against tricky strings like `<script>alert('XSS')</script>` or emojis 🐛😺
