### PR TITLE
[AT-3288] BinanceAPI wrapper: Subaccount API keys create and delete

### DIFF
--- a/spec/binance_api/brokerage_spec.rb
+++ b/spec/binance_api/brokerage_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe BinanceAPI::Brokerage, :vcr do
       let(:subaccount_id) { '494553304457687040' }
 
       it 'returns result with expected keys' do
-        result = brokerage.get_subaccount(subaccount_id)
+        result = brokerage.get_subaccount(sub_account_id: subaccount_id)
 
         expect(result.value.first.keys).to include(:subaccountId, :createTime, :makerCommission)
       end
@@ -43,13 +43,164 @@ RSpec.describe BinanceAPI::Brokerage, :vcr do
       let(:subaccount_id) { '-1' }
 
       it 'throws BinanceAPI::RequestError' do
-        expect { brokerage.get_subaccount(subaccount_id) }.to raise_error(BinanceAPI::RequestError)
+        expect { brokerage.get_subaccount(sub_account_id: subaccount_id) }.to(
+          raise_error(BinanceAPI::RequestError)
+        )
       end
 
       it 'throws exception with error message and code' do
-        brokerage.get_subaccount(subaccount_id)
+        brokerage.get_subaccount(sub_account_id: subaccount_id)
       rescue => e
         expect(e.message).to include('This two users are not in parent-child relation')
+        expect(e.status).to eq(400)
+      end
+    end
+  end
+
+  describe '.create_subaccount_key' do
+    let(:api_call) do
+      brokerage.create_subaccount_key(sub_account_id: subaccount_id, can_trade: can_trade)
+    end
+
+    context 'when valid subaccount ID' do
+      let(:subaccount_id) { '495279769361068032' }
+      let(:can_trade) { true }
+
+      it 'returns result with expected keys' do
+        result = api_call
+        expect(result.value.keys).to(
+          include(:apiKey, :secretKey, :subaccountId, :canTrade, :marginTrade, :futuresTrade)
+        )
+      end
+    end
+
+    context 'when invalid subaccount ID' do
+      let(:subaccount_id) { '-1' }
+      let(:can_trade) { true }
+
+      it 'throws BinanceAPI::RequestError' do
+        expect { api_call }.to(
+          raise_error(BinanceAPI::RequestError)
+        )
+      end
+
+      it 'throws exception with error message' do
+        api_call
+      rescue => e
+        expect(e.message).to include('This two users are not in parent-child relation')
+      end
+
+      it 'throws exception with error code' do
+        api_call
+      rescue => e
+        expect(e.status).to eq(400)
+      end
+    end
+
+    context 'when mandatory param is missing' do
+      let(:subaccount_id) { '495279769361068032' }
+      let(:can_trade) { nil }
+
+      it 'throws BinanceAPI::RequestError' do
+        expect { api_call }.to(
+          raise_error(BinanceAPI::RequestError)
+        )
+      end
+
+      it 'throws exception with error message' do
+        api_call
+      rescue => e
+        expect(e.message).to include("Mandatory parameter 'canTrade is not null' was not sent")
+      end
+
+      it 'throws exception with error code' do
+        api_call
+      rescue => e
+        expect(e.status).to eq(400)
+      end
+    end
+  end
+
+  describe '.delete_subaccount_key' do
+    let(:api_call) do
+      brokerage.delete_subaccount_key(sub_account_id: subaccount_id, sub_account_api_key: api_key)
+    end
+
+    context 'when valid params' do
+      let(:subaccount_id) { '495279769361068032' }
+      let(:api_key) { 'CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM' }
+
+      it 'returns result with expected keys' do
+        result = api_call
+        expect(result.value).to be_eql({})
+      end
+    end
+
+    context 'when API key does not exist' do
+      let(:subaccount_id) { '495279769361068032' }
+      let(:api_key) { 'CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM' }
+
+      it 'throws BinanceAPI::RequestError' do
+        expect { api_call }.to(
+          raise_error(BinanceAPI::RequestError)
+        )
+      end
+
+      it 'throws exception with error message and code' do
+        api_call
+      rescue => e
+        expect(e.message).to include('API key does not exist')
+      end
+
+      it 'throws exception with error code' do
+        api_call
+      rescue => e
+        expect(e.status).to eq(400)
+      end
+    end
+
+    context 'when invalid subaccount ID' do
+      let(:subaccount_id) { '-1' }
+      let(:api_key) { 'CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM' }
+
+      it 'throws BinanceAPI::RequestError' do
+        expect { api_call }.to(
+          raise_error(BinanceAPI::RequestError)
+        )
+      end
+
+      it 'throws exception with error message and code' do
+        api_call
+      rescue => e
+        expect(e.message).to include('This two users are not in parent-child relation')
+      end
+
+      it 'throws exception with error code' do
+        api_call
+      rescue => e
+        expect(e.status).to eq(400)
+      end
+    end
+
+    context 'when mandatory param is missing' do
+      let(:subaccount_id) { '495279769361068032' }
+      let(:api_key) { nil }
+
+      it 'throws BinanceAPI::RequestError' do
+        expect { api_call }.to(
+          raise_error(BinanceAPI::RequestError)
+        )
+      end
+
+      it 'throws exception with error message' do
+        api_call
+      rescue => e
+        expect(e.message).to include("Mandatory parameter 'subAccountApiKey is not null' was not sent")
+      end
+
+      it 'throws exception with error code' do
+        api_call
+      rescue => e
         expect(e.status).to eq(400)
       end
     end

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_BinanceAPI_RequestError.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_BinanceAPI_RequestError.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=-1&canTrade=true&recvWindow=5000&timestamp=1596046335000&signature=7c6e088afc863801ff3fde71f348b320a43c6132827c9f5d4aa725f214337243
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:12:15 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=4116D56C27E65ACDACA4FB595DCBEF5E; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 7210fed509d8e341021bffe29c62787c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - 9h6jrMyqMZx_ePrtzxzcNZ_3gmqwDkFSw1b9qFBfre6FZUNS2BOb0g==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Wed, 29 Jul 2020 18:12:16 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_code.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=-1&canTrade=true&recvWindow=5000&timestamp=1596048426000&signature=70a95e2251bde195e1cb5a7c45712576d260b284d6053c3b3816ed5c92d40e20
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:47:06 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=3F08B667A463FD275943B6A24E76FC41; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 1c140222cf7df6d0df745770e90c311a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - GNteb82O6YT5rN1WmO7bUOJ54Qlk7qCuPTynx1_iA0uAVPCEgXNpdw==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Wed, 29 Jul 2020 18:47:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_message.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_message.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=-1&canTrade=true&recvWindow=5000&timestamp=1596048425000&signature=203a36a3f82d04fe3391043422b18865070f22ef2a09608cf0afcd11568ca6cf
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:47:06 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=2DBDF1E7D715A51E515950049E8D2FE3; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 a05b3de6d2658c4fd69effef7a8348e4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - TI12TvjgZY3aCFUPBOuxN1wl-ajtZ80XSuQhl2PTE_lRq2-uBgiKrw==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Wed, 29 Jul 2020 18:47:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_message_and_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_message_and_code.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=-1&canTrade=true&recvWindow=5000&timestamp=1596046336000&signature=6f12147f2fd6d8d3774b195495eaf7e56bd5086208a8e79843003082e8b52277
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:12:16 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=EBF56F3A18C76F2B4B4414FCB1315806; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 a3735c121c062c1788822db6bee539a8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - quf4bbsDCMSZ8yZ2Wivm9w6xlqDZOG7Uk_MBle_hM6TwxynM3I-mUw==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Wed, 29 Jul 2020 18:12:16 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_BinanceAPI_RequestError.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_BinanceAPI_RequestError.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&recvWindow=5000&timestamp=1596046712000&signature=9e5c7f5f665a2abda1f92cc8585199dee45775334bcd694dc56852fbf81b490f
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '146'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '109'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:18:33 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=F49321030B6C9C299E0B380C4E2755D6; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 13182ff42379bbc1098730eb0992dbae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - ZiDGEE6jsznTviiveirS2UYpi1WPAcER0sEifMGlsDJEQlR-DjV8BA==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''canTrade is not null'' was
+        not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 18:18:33 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_code.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&recvWindow=5000&timestamp=1596048427000&signature=76cd11222a3c3d4c99fa3e7c95ade9242da3caca1db00f6c26cccf13edcf6756
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '146'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '109'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:47:07 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=9CC49FA3A856610D44D073CFE2E238BB; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 5e71ebbd3e768e1e564c88b3632039d8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - VUL4aOfgc-fZpBN7K38bXg-iza-XPZ6aVq6OYf14GEf5FBaEQS1eTQ==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''canTrade is not null'' was
+        not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 18:47:07 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_message.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_message.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&recvWindow=5000&timestamp=1596048426000&signature=5d5504992a3bada8c67e618226f5e6492259d9a8015dfc92ec705ca1b24fdb2f
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '146'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '109'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:47:07 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=0D0079C061446D047835B785ED342000; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 f62050e21268ac5026b6ccb68a1f0a2b.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - Jn3WvzhwFgMEzIK0SxmdqB1ljRlbKpVp7nH_dj1St8u02_bY0CHgAg==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''canTrade is not null'' was
+        not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 18:47:07 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_message_and_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_message_and_code.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&recvWindow=5000&timestamp=1596046713000&signature=1b3b30c02c366b6a19451914b565bfa2b57a75810501c256c07df5d9e1dc5b4a
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '146'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '109'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:18:34 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=BAA29E48AF6755361D664B2E5439492F; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 5d40d4ac7c3a1e18748166636540091f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - R_6EzcAf4PbkP63f7ASH18dNzciloRvO6fVOIQU85mo2o5uNGNjezg==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''canTrade is not null'' was
+        not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 18:18:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenValidSubaccountID/returns_result_with_expected_keys.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/CreateSubaccountKey/WhenValidSubaccountID/returns_result_with_expected_keys.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&canTrade=true&recvWindow=5000&timestamp=1596046334000&signature=8389880a991673ef4c9647dfea3cab63d5c5e1658a446e58ab7566d125a7d462
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '249'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:12:15 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=861DE7BCEB8FC822E5DB2FF24D65D9CD; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, OPTIONS
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c35525724b74ec2ec80741ffbf1ff218.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - tzFzGOj2s-y-86fFLhyjR8bBe6NGVBSExBxKnCeInyKL-MssCsNSTQ==
+    body:
+      encoding: UTF-8
+      string: '{"apiKey":"CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM","secretKey":"nmfnYs9CiwAijoUedmcMVShKyGtUEYtVXlHnWMhNc6XO9hkbWTRJ7P8srR8SML9t","subaccountId":"495279769361068032","canTrade":true,"marginTrade":false,"futuresTrade":false}'
+  recorded_at: Wed, 29 Jul 2020 18:12:15 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenAPIKeyDoesNotExist/throws_BinanceAPI_RequestError.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenAPIKeyDoesNotExist/throws_BinanceAPI_RequestError.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&subAccountApiKey=CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM&recvWindow=5000&timestamp=1596048968000&signature=d6c8a0be572961e0e7fa65d84d229a69888d14e36660ee147eae9a1fbd03d81f
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '228'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:56:08 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=29C908ADC1DD46980DB8313E99B77610; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 2e8f70eb03b681aa6bd8c18fff081f80.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - AB6sgUyZS-dTjjULpFnG88raiYQ9EHhpIdEC2qKiQw4y2yik84ge5A==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"API key does not exist"}'
+  recorded_at: Wed, 29 Jul 2020 18:56:09 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenAPIKeyDoesNotExist/throws_exception_with_error_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenAPIKeyDoesNotExist/throws_exception_with_error_code.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&subAccountApiKey=CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM&recvWindow=5000&timestamp=1596048969000&signature=83abf629b668456f5e6accb406a3a68310b0e24e1976b3d456c9d35851441ce2
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '228'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:56:09 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=81AFFA2B69CD9A97EF6CAC24ACDB752C; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 dce4c8b7b9f77858bc00bb5154e30f3c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - qG4YeHcu_sCrGiyCEB_htbzoQicyLZj_HuuEUsHn8ZEOHDqWwkFlKw==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"API key does not exist"}'
+  recorded_at: Wed, 29 Jul 2020 18:56:09 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenAPIKeyDoesNotExist/throws_exception_with_error_message_and_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenAPIKeyDoesNotExist/throws_exception_with_error_message_and_code.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&subAccountApiKey=CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM&recvWindow=5000&timestamp=1596048969000&signature=83abf629b668456f5e6accb406a3a68310b0e24e1976b3d456c9d35851441ce2
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '228'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:56:09 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=827E9AA49F22C9577F28AB4B25BE9122; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 a05b3de6d2658c4fd69effef7a8348e4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - fW64qz9pn9kqfClT6Chx_Bq3MAbX_3cAtuvjg3AoAsUTzrWQLrbu5A==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"API key does not exist"}'
+  recorded_at: Wed, 29 Jul 2020 18:56:09 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenInvalidSubaccountID/throws_BinanceAPI_RequestError.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenInvalidSubaccountID/throws_BinanceAPI_RequestError.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=-1&subAccountApiKey=CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM&recvWindow=5000&timestamp=1596048190000&signature=db429fae170b8e38f8bc96a0e3e76fd510217194734c91ec7364231be8ad5ca7
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:43:10 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=E3B6D199CADBEA20013C5EFE817FACB4; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 58bdfbab355a53b4cbc6b93312bb8749.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - O-Ehj04z27l_Dt1bzhi9cRwctgaOMBYuMDXiuO3xd4PL5szbz7EA4w==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Wed, 29 Jul 2020 18:43:10 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_code.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=-1&subAccountApiKey=CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM&recvWindow=5000&timestamp=1596048331000&signature=26d0e41c502c10606d38f104c39dbea2054b12874c6968b4a1b235fcf4893410
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:45:32 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=F6EBF0FED4B2321B009EF1E6A103B3C0; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 4cea94b0894987ae880983d50307d214.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - oSgZs8d9wvIT-jpigy2oMq-Snmd4mGIaID8_AG_qTZAIrdj6vfz3WA==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Wed, 29 Jul 2020 18:45:32 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_message_and_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenInvalidSubaccountID/throws_exception_with_error_message_and_code.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=-1&subAccountApiKey=CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM&recvWindow=5000&timestamp=1596048475000&signature=02e6781023b2d51867fb5121e2e0b1bc68d60e2145c74f9013042df1b380cced
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:47:56 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=10E1088C4B71C9B8D5FCD7FD813F0390; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 5d40d4ac7c3a1e18748166636540091f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - le7GZDFDjseHY6W4ijbjjmjGR3RjOHizztWR68rtxMwKWuQCwPt8BA==
+    body:
+      encoding: UTF-8
+      string: '{"code":-9000,"msg":"This two users are not in parent-child relation."}'
+  recorded_at: Wed, 29 Jul 2020 18:47:56 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenMandatoryParamIsMissing/throws_BinanceAPI_RequestError.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenMandatoryParamIsMissing/throws_BinanceAPI_RequestError.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&recvWindow=5000&timestamp=1596048190000&signature=97b56ea012473c6290192a12b079f28422914964aff081fcf55b2c370e37b55d
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '146'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '117'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:43:11 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=CD95E950412303D029AD6620E3FCB41D; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 13182ff42379bbc1098730eb0992dbae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - jsmUPC-FncYSL601uwlcQ0e-mg4Dj7o-sLRj_Tqr_2x-PUs7geI7Rg==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''subAccountApiKey is not
+        null'' was not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 18:43:11 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_code.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_code.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&recvWindow=5000&timestamp=1596048332000&signature=faa4d60146bd6d55d99d0de740afc7703f766dc08c5dfc36d82c1b7c7b78d303
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '146'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '117'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:45:33 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=88F8C843FBF10D99558477C19EAC08D3; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 50f21cb925e6471490e080147e252d7d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - 2LgbYxrpFYpc_Rwo20hfZsam0AGebTC1wanOKrgSQHn8N1Chfd5bwA==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''subAccountApiKey is not
+        null'' was not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 18:45:33 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_message.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenMandatoryParamIsMissing/throws_exception_with_error_message.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&recvWindow=5000&timestamp=1596048332000&signature=faa4d60146bd6d55d99d0de740afc7703f766dc08c5dfc36d82c1b7c7b78d303
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '146'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '117'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:45:32 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=E5D999616B0ED1A35135786885D44EA0; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 dce4c8b7b9f77858bc00bb5154e30f3c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - TKofGPNDiSzTweiMUx-8FAaQcBxWpCfTpAQkY74cAEF5xtCNnBQnJg==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''subAccountApiKey is not
+        null'' was not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 18:45:32 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenValidParams/returns_result_with_expected_keys.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/DeleteSubaccountKey/WhenValidParams/returns_result_with_expected_keys.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: subAccountId=495279769361068032&subAccountApiKey=CgXjYwP2AwWapJKEyKqbZ1BgcOtFkrUBomefbrw2hDGLyigvrEL4i7DXpc5ofjQM&recvWindow=5000&timestamp=1596048189000&signature=2399504d9a26394577cccf3cbaaea58211eb3d30dfd3d78844b79612576b591f
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '228'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 18:43:09 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=3886165AAD989717590369096146B43E; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, OPTIONS
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 5d40d4ac7c3a1e18748166636540091f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - GR9EhvRACk-xClRweoJnM1cttX1KDRUNhUYEzqt6B0BvJxW2v74FhA==
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 29 Jul 2020 18:43:10 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/test.yml
+++ b/spec/fixtures/vcr_cassettes/BinanceAPIBrokerage/test.yml
@@ -1,0 +1,216 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: recvWindow=5000&timestamp=1596013214000&signature=ed18a8fd96b7daf5ad849e036da82c6adc184f0ed547364ac55dfa0767c3b599
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '134'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 09:00:14 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=3463BEAC0BF715AEF123DBE3878D6C91; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 50f21cb925e6471490e080147e252d7d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - ntdblIuQ_tvSu5UVGkN_O_9APG6NNym9ndEKEoiF-bSiX4TM7IKGJA==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''canTrade is not null|subAccountId
+        is not null'' was not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 09:00:14 GMT
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: recvWindow=5000&timestamp=1596013227000&signature=79826d28d846fc23807a978b74aa0ad6789cd9f3e6d0c8a407df30954a8dc8aa
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '134'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 09:00:27 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=BCBCD58E57870487E5070FDB29221B18; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 7cd2262b9bb2f116de2e74d9d97ab5d1.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - mgvsp0vbbD1z-14G91GmR0fYmtk6P78-R6xYFEImQOOgy-iJxZuE0A==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''canTrade is not null|subAccountId
+        is not null'' was not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 09:00:27 GMT
+- request:
+    method: post
+    uri: https://api.binance.com/sapi/v1/broker/subAccountApi
+    body:
+      encoding: UTF-8
+      string: recvWindow=5000&timestamp=1596013268000&signature=29156cd5993707402b8832bcdd7c3ee3a963b2c85f49273974357cab12dafb9a
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin19.5.0 x86_64) ruby/2.6.5p114
+      X-Mbx-Apikey:
+      - b3gxC40YDY5UaGj4uxr5feKb5hM03aJQ8ke79sn3Kbi55IntSvVp3cqXajeTYZpk
+      Content-Length:
+      - '114'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.binance.com
+  response:
+    status:
+      code: 400
+      message: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '134'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Jul 2020 09:01:08 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - JSESSIONID=041F983637039E133C4B5AE96FDA13BA; Path=/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'
+      X-Content-Security-Policy:
+      - default-src 'self'
+      X-Webkit-Csp:
+      - default-src 'self'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Cache:
+      - Error from cloudfront
+      Via:
+      - 1.1 b3b1689b5de3293227c415784ed3c268.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Amz-Cf-Id:
+      - 8fQWTfGrK_SfZIyl1A8TSmVwDKUH9SXeFoID3DKY9bNLmZGn0Dy-zw==
+    body:
+      encoding: UTF-8
+      string: '{"code":-1102,"msg":"Mandatory parameter ''subAccountId is not null|canTrade
+        is not null'' was not sent, was empty/null, or malformed."}'
+  recorded_at: Wed, 29 Jul 2020 09:01:08 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Add here link to Jira, but let this not be the only content in this section -->
**[JIRA ticket](https://banktothefuture.atlassian.net/browse/AT-3288)**

Possibility to create and delete sub-account API keys.

## Description
<!--- Describe what you have done and why have you done it this way -->

- created `BinanceAPI::Brokerage#create_subaccount_key`
- created `BinanceAPI::Brokerage#delete_subaccount_key`
- added snake case mapping into lower camel case
- tested everything

## Screenshots (if appropriate):

N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added tests that cover each case.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
- [ ] I have added feature flags to hide new changes on production
- [ ] I have tested if data is not visible by other user (through modified API call, or URL change)
- [ ] I have tested what happens if I resubmit form or API call few times
- [ ] I have tested inputs against tricky strings like `<script>alert('XSS')</script>` or emojis 🐛😺
